### PR TITLE
Restrict To Self removed from non-user endpoints

### DIFF
--- a/app/routes/tickets/tickets-router.js
+++ b/app/routes/tickets/tickets-router.js
@@ -9,24 +9,14 @@ const middlewares = require("../../middlewares");
 const ticket_router = express.Router();
 const json_parser = body_parser.json();
 
-// Ticket ID route parameter handler.
 ticket_router.param("ticket", tickets_route_param_handlers.ticket_param_handler);
 ticket_router.param("event", event_route_param_handlers.event_param_handler);
 ticket_router.param("user", users_route_param_handlers.user_param_handler);
 
-// Get all tickets of user (self).
-ticket_router.all("/all", middlewares.validate_user, middlewares.restrict_to_self, json_parser, tickets_controller.get_all_tickets);
-
-// Get one ticket of user (self).
-ticket_router.get("/:ticket", middlewares.validate_user, middlewares.restrict_to_self, json_parser, tickets_controller.get_ticket);
-
-// Create ticket for user at event.
-ticket_router.post("/:event", middlewares.validate_user, middlewares.restrict_to_self, json_parser, tickets_controller.create_ticket);
-
-// Update ticket with ID.
+ticket_router.all("/all", middlewares.validate_user, json_parser, tickets_controller.get_all_tickets);
+ticket_router.get("/:ticket", middlewares.validate_user, json_parser, tickets_controller.get_ticket);
+ticket_router.post("/:event", middlewares.validate_user, json_parser, tickets_controller.create_ticket);
 ticket_router.patch("/:ticket", middlewares.restrict_to_admin, json_parser, tickets_controller.update_ticket);
-
-// Delete ticket with ID.
 ticket_router.delete("/:ticket", middlewares.restrict_to_admin, json_parser, tickets_controller.delete_ticket);
 
 module.exports = ticket_router;


### PR DESCRIPTION
Restrict-To-Self is only valid for user endpoints since the user is attached to request. Other than that, verifying user is enough. This is why Restrict-To-Self is removed from ticket endpoint.